### PR TITLE
project interface responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Project.ts
+++ b/src/clients/FlexbaseClient.Project.ts
@@ -1,26 +1,7 @@
-import { Project } from '../models/Project/Project';
+import { CreateProjectResponse, Project, ProjectsResponse } from '../models/Project/Project';
 import { FlexbaseClientBase } from './FlexbaseClient.Base';
 
-interface ProjectsResponse {
-    companyId: string;
-    contracts: Array<string>;
-    description: string;
-    id: string;
-    location: Array<string>;
-    name: string;
-}
 
-interface CreateProjectResponse {
-  description: string;
-  id: string;
-  location: {
-      address: string;
-      city: string;
-      postalCode: string;
-      state: string;
-  },
-  name: string;
-}
 
 export class FlexbaseClientProject extends FlexbaseClientBase {
     async getCompanyProjects(): Promise<ProjectsResponse[] | null> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,4 @@ export { Card } from './models/Card/Card';
 export { OnboardingStatus } from './models/Onboarding/OnboardingStatus';
 export { Business } from './models/Business/Business';
 export { BusinessOwner } from './models/Business/BusinessOwner';
-export { Project } from './models/Project/Project';
+export { Project, ProjectsResponse, CreateProjectResponse } from './models/Project/Project';

--- a/src/models/Project/Project.ts
+++ b/src/models/Project/Project.ts
@@ -6,3 +6,19 @@ export interface Project {
     description?: string;
     location?: Address
 }
+
+export interface ProjectsResponse {
+    companyId: string;
+    contracts: Array<string>;
+    description: string;
+    id: string;
+    location: Address;
+    name: string;
+}
+
+export interface CreateProjectResponse {
+  description: string;
+  id: string;
+  location: Address;
+  name: string;
+}


### PR DESCRIPTION
This PR was created to add the export to the `ProjectsResponse` and `CreateProjectResponse` interfaces in order to import them into the `flexbase-web` repository.

- add the interface ProjectsResponse and CreateProjectResponse to the model's folder and add the option to export the interfaces