### PR TITLE
Cards actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Card.ts
+++ b/src/clients/FlexbaseClient.Card.ts
@@ -117,7 +117,7 @@ export class FlexbaseClientCard extends FlexbaseClientBase {
       }
     }
 
-    async updateCardStatus(cardId: string, status: string, last4?: string): Promise<CardResponse> {
+    async updateCardStatus(cardId: string, status: 'active' | 'suspended' | 'terminated', last4?: string): Promise<CardResponse> {
       try {
         const response = await this.client.url('/card/status').put({cardId, status, last4}).json<CardResponse>();
 

--- a/src/clients/FlexbaseClient.Card.ts
+++ b/src/clients/FlexbaseClient.Card.ts
@@ -121,6 +121,10 @@ export class FlexbaseClientCard extends FlexbaseClientBase {
       try {
         const response = await this.client.url('/card/status').put({cardId, status, last4}).json<CardResponse>();
 
+        if (!response.success) {
+          this.logger.error('Unable to update the card status', response.error);
+        }
+
         return response;
       } catch (error) {
         this.logger.error('Unable to update the card status', error);

--- a/src/clients/FlexbaseClient.Card.ts
+++ b/src/clients/FlexbaseClient.Card.ts
@@ -121,11 +121,6 @@ export class FlexbaseClientCard extends FlexbaseClientBase {
       try {
         const response = await this.client.url('/card/status').put({cardId, status, last4}).json<CardResponse>();
 
-        if (!response.success) {
-          this.logger.error('Unable to update the card status');
-          return response;
-        }
-
         return response;
       } catch (error) {
         this.logger.error('Unable to update the card status', error);

--- a/src/clients/FlexbaseClient.Card.ts
+++ b/src/clients/FlexbaseClient.Card.ts
@@ -116,4 +116,20 @@ export class FlexbaseClientCard extends FlexbaseClientBase {
         return { success: false, error: 'Unable to update the card info', card: null };
       }
     }
+
+    async updateCardStatus(cardId: string, status: string, last4?: string): Promise<CardResponse> {
+      try {
+        const response = await this.client.url('/card/status').put({cardId, status, last4}).json<CardResponse>();
+
+        if (!response.success) {
+          this.logger.error('Unable to update the card status');
+          return response;
+        }
+
+        return response;
+      } catch (error) {
+        this.logger.error('Unable to update the card status', error);
+        return { success: false, error: 'Unable to update the card status', card: null };
+      }
+    }
 }

--- a/tests/clients/FlexbaseClient.Card.test.ts
+++ b/tests/clients/FlexbaseClient.Card.test.ts
@@ -151,20 +151,6 @@ test("FlexbaseClient activate card", async () => {
     expect(response?.card?.status).toBe('active');
 });
 
-test("FlexbaseClient update card status", async () => {
-
-    const status = 'active';
-
-    const response = await testFlexbaseClient.updateCardStatus(goodCardId, status);
-
-    expect(response).not.toBeNull();
-
-    expect(response?.card?.id).toBe(goodCardId);
-    expect(response?.card?.cardName).toBe('Gas Card');
-    expect(response?.card?.cardNumber).toBe('1234');
-    expect(response?.card?.status).toBe('active');
-});
-
 test("FlexbaseClient update card status failure", async () => {
 
     server.use(...card_failure_handlers);

--- a/tests/clients/FlexbaseClient.Card.test.ts
+++ b/tests/clients/FlexbaseClient.Card.test.ts
@@ -133,3 +133,57 @@ test("FlexbaseClient update user card error", async () => {
     expect(response.error).toBe('Unable to update the card info');
     expect(response.card).toBeNull();
 });
+
+// Change card status
+test("FlexbaseClient activate card", async () => {
+
+    const last4 = '1234';
+    const status = 'active';
+    const cardId = goodCardId;
+
+    const response = await testFlexbaseClient.updateCardStatus(cardId, status, last4);
+
+    expect(response).not.toBeNull();
+
+    expect(response?.card?.id).toBe(goodCardId);
+    expect(response?.card?.cardName).toBe('Gas Card');
+    expect(response?.card?.cardNumber).toBe('1234');
+    expect(response?.card?.status).toBe('active');
+});
+
+test("FlexbaseClient update card status", async () => {
+
+    const status = 'active';
+
+    const response = await testFlexbaseClient.updateCardStatus(goodCardId, status);
+
+    expect(response).not.toBeNull();
+
+    expect(response?.card?.id).toBe(goodCardId);
+    expect(response?.card?.cardName).toBe('Gas Card');
+    expect(response?.card?.cardNumber).toBe('1234');
+    expect(response?.card?.status).toBe('active');
+});
+
+test("FlexbaseClient update card status failure", async () => {
+
+    server.use(...card_failure_handlers);
+
+    const status = 'suspended';
+    const response = await testFlexbaseClient.updateCardStatus(badCardId, status);
+
+    expect(response.success).toBeFalsy();
+    expect(response.error).toBe('Error message');
+});
+
+test("FlexbaseClient update card status error", async () => {
+
+    server.use(...card_error_handlers);
+
+    const status = 'suspended';
+    const response = await testFlexbaseClient.updateCardStatus(badCardId, status);
+
+    expect(response.card).toBeNull();
+    expect(response.success).toBeFalsy();
+    expect(response.error).toBe('Unable to update the card status');
+});

--- a/tests/mocks/server/handlers/card.ts
+++ b/tests/mocks/server/handlers/card.ts
@@ -134,6 +134,25 @@ export const card_handlers = [
         );
         return response(res);
     }),
+
+    mockServer.put(mockUrl + "/card/status", (request, response, context) => {
+
+        const res = compose(
+            context.status(200),
+            context.json({
+                success: true,
+                card: {
+                    id: goodCardId,
+                    cardName: 'Gas Card',
+                    cardNumber: "1234",
+                    creditLimit: 5000,
+                    status: 'active',
+                },
+            }),
+
+        );
+        return response(res);
+    }),
 ]
 
 export const card_failure_handlers = [
@@ -143,6 +162,19 @@ export const card_failure_handlers = [
             context.status(200),
             context.json({
                 success: false,               
+            }),
+    
+        );
+        return response(res);
+    }),
+
+    mockServer.put(mockUrl + "/card/status", (_, response, context) => {
+
+        const res = compose(
+            context.status(200),
+            context.json({
+                success: false,
+                error: "Error message",               
             }),
     
         );
@@ -158,4 +190,13 @@ export const card_error_handlers = [
         );
         return response(res);
     }),
+
+    mockServer.put(mockUrl + "/card/status", (_, response, context) => {
+
+        const res = compose(
+            context.status(400),
+        );
+        return response(res);
+    }),
 ];
+


### PR DESCRIPTION
This PR was made to add the `PUT /card/status` endpoint where we can update the card status for `active`, `suspended`, and `terminated`.

For `updateCardStatus()` call, we need to pass the `cardId`, `status` (the status that we want to change to the card), and if we need to activate for the first time a **physical card** we need to pass `last4` which is the last four numbers for the card.