### PR TITLE
Add endpoint for getting a BNPL request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.6",
+  "version": "0.33.7",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Credit.ts
+++ b/src/clients/FlexbaseClient.Credit.ts
@@ -1,4 +1,8 @@
-import { PayWithFlexbase, PayWithFlexbaseResponse } from '../models/Credit/PayWithFlexbase';
+import {
+    PayWithFlexbase,
+    PayWithFlexbaseResponse,
+    RequestPayWithFlexbaseResponse
+} from '../models/Credit/PayWithFlexbase';
 import { CompanyCredit } from '../models/Credit/CompanyCredit';
 import { FlexbaseResponse } from '../models/FlexbaseResponse';
 import { FlexbaseClientBase } from './FlexbaseClient.Base';
@@ -88,5 +92,20 @@ export class FlexbaseClientCredit extends FlexbaseClientBase {
             this.logger.error('Unable to pay with flexbase', payload, error);
             return { approved: false };
         }
+    }
+
+    async getBnplRequest(id: string): Promise<RequestPayWithFlexbaseResponse> {
+        if (!id ) {
+            throw new Error('ID is required');
+        }
+
+        const result = await this.client.url(`/credit/request/${id}`).get().json<RequestPayWithFlexbaseResponse>();
+
+        if (!result.success) {
+            this.logger.error('Error retrieving BNPL request');
+            throw new Error('Could not find BNPL request.');
+        }
+
+        return result;
     }
 }

--- a/src/clients/FlexbaseClient.Credit.ts
+++ b/src/clients/FlexbaseClient.Credit.ts
@@ -79,6 +79,10 @@ export class FlexbaseClientCredit extends FlexbaseClientBase {
             throw new Error('apiKey is required and amount must be greater than 0');
         }
 
+        if (!payload.bnplRequest) {
+            throw new Error('A BNPL request ID is required to initiate Pay with Flexbase')
+        }
+
         try {
             const response = await this.client.url('/credit/buyNow').post(payload).json<PayWithFlexbaseResponseWrapper>();
 

--- a/src/clients/FlexbaseClient.Credit.ts
+++ b/src/clients/FlexbaseClient.Credit.ts
@@ -76,7 +76,7 @@ export class FlexbaseClientCredit extends FlexbaseClientBase {
             throw new Error('apiKey is required and amount must be greater than 0');
         }
 
-        if (!payload.bnplRequest) {
+        if (!payload.requestId) {
             throw new Error('A BNPL request ID is required to initiate Pay with Flexbase');
         }
 

--- a/src/models/Credit/PayWithFlexbase.ts
+++ b/src/models/Credit/PayWithFlexbase.ts
@@ -25,7 +25,6 @@ export interface PayWithFlexbaseInvoice {
     session: string;
 }
 
-
 // This isn't confusingly named at all
 export interface RequestPayWithFlexbaseResponse extends FlexbaseResponse {
     id: string;

--- a/src/models/Credit/PayWithFlexbase.ts
+++ b/src/models/Credit/PayWithFlexbase.ts
@@ -9,6 +9,7 @@ export interface PayWithFlexbase {
     session?: string;
     mode: PayWithFlexbaseMode;
     description?: string;
+    bnplRequest: string;
 }
 
 export interface PayWithFlexbaseResponse {

--- a/src/models/Credit/PayWithFlexbase.ts
+++ b/src/models/Credit/PayWithFlexbase.ts
@@ -1,4 +1,5 @@
 import { Merchant } from '../Merchant/Merchant';
+import { FlexbaseResponse } from '../FlexbaseResponse';
 
 export type PayWithFlexbaseMode = 'immediate';
 
@@ -21,4 +22,12 @@ export interface PayWithFlexbaseInvoice {
     amount: number;
     status: string;
     session: string;
+}
+
+
+// This isn't confusingly named at all
+export interface RequestPayWithFlexbaseResponse extends FlexbaseResponse {
+    id: string;
+    amount: number;
+    status: 'pending' | 'consumed';
 }

--- a/src/models/Credit/PayWithFlexbase.ts
+++ b/src/models/Credit/PayWithFlexbase.ts
@@ -9,7 +9,7 @@ export interface PayWithFlexbase {
     session?: string;
     mode: PayWithFlexbaseMode;
     description?: string;
-    bnplRequest: string;
+    requestId: string;
 }
 
 export interface PayWithFlexbaseResponse {

--- a/tests/clients/FlexbaseClient.Credit.test.ts
+++ b/tests/clients/FlexbaseClient.Credit.test.ts
@@ -37,7 +37,7 @@ test("FlexbaseClient get company credit no id", async () => {
 
 test("FlexbaseClient request pay with flexbase success", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 1000, session: "test", mode: 'immediate' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 1000, session: "test", mode: 'immediate', bnplRequest: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(true);
@@ -49,7 +49,7 @@ test("FlexbaseClient request pay with flexbase success", async () => {
 
 test("FlexbaseClient request pay with flexbase failure", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: badApiKey, amount: 1000, mode: 'immediate' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: badApiKey, amount: 1000, mode: 'immediate', bnplRequest: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(false);
@@ -57,7 +57,7 @@ test("FlexbaseClient request pay with flexbase failure", async () => {
 
 test("FlexbaseClient request pay with flexbase error", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: errorApiKey, amount: 1000, mode: 'immediate' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: errorApiKey, amount: 1000, mode: 'immediate', bnplRequest: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(false);
@@ -65,7 +65,7 @@ test("FlexbaseClient request pay with flexbase error", async () => {
 
 test("FlexbaseClient request pay with flexbase denied", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: deniedApiKey, amount: 1000, mode: 'immediate' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: deniedApiKey, amount: 1000, mode: 'immediate', bnplRequest: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(false);
@@ -73,9 +73,12 @@ test("FlexbaseClient request pay with flexbase denied", async () => {
 
 test("FlexbaseClient request pay with flexbase invalid payload", async () => {
 
-    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: '', amount: 1000, mode: 'immediate' })).rejects.toThrow();
+    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: '', amount: 1000, mode: 'immediate', bnplRequest: 'test' })).rejects.toThrow();
 
-    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate' })).rejects.toThrow();
+    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate', bnplRequest: 'test' })).rejects.toThrow();
+
+    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate', bnplRequest: '' })).rejects.toThrow();
+
 });
 
 
@@ -94,3 +97,25 @@ test("FlexbaseClient pay debt error", async () => {
     const response = await testFlexbaseClient.payDebt('', '');
     expect(response.error).toBe('Unable to make the pay debt');
 });
+
+
+
+describe('Get BNPL request', () => {
+    test('Should successfully return the request', async () => {
+        const response = await testFlexbaseClient.getBnplRequest('12345');
+        expect(response.status).toBeTruthy();
+    });
+
+    test('Should throw an error if ID is not provided', async () => {
+        await expect(testFlexbaseClient.getBnplRequest('' as any)).rejects.toThrow('ID is required');
+    });
+
+    test('Should throw an error if not found', async () => {
+        await expect(testFlexbaseClient.getBnplRequest(badCompanyId)).rejects.toThrow('Could not find BNPL request.');
+    });
+
+    test('Should error', async () => {
+        await expect(testFlexbaseClient.getBnplRequest(errorCompanyId)).rejects.toThrow();
+    });
+
+})

--- a/tests/clients/FlexbaseClient.Credit.test.ts
+++ b/tests/clients/FlexbaseClient.Credit.test.ts
@@ -103,19 +103,21 @@ test("FlexbaseClient pay debt error", async () => {
 describe('Get BNPL request', () => {
     test('Should successfully return the request', async () => {
         const response = await testFlexbaseClient.getBnplRequest('12345');
-        expect(response.status).toBeTruthy();
+        expect(response?.status).toBeTruthy();
     });
 
     test('Should throw an error if ID is not provided', async () => {
         await expect(testFlexbaseClient.getBnplRequest('' as any)).rejects.toThrow('ID is required');
     });
 
-    test('Should throw an error if not found', async () => {
-        await expect(testFlexbaseClient.getBnplRequest(badCompanyId)).rejects.toThrow('Could not find BNPL request.');
+    test('Should return null if not found', async () => {
+        const result = await testFlexbaseClient.getBnplRequest(badCompanyId);
+        expect(result).toBeNull();
     });
 
     test('Should error', async () => {
-        await expect(testFlexbaseClient.getBnplRequest(errorCompanyId)).rejects.toThrow();
+        const result = await testFlexbaseClient.getBnplRequest(errorCompanyId);
+        expect(result).toBeNull();
     });
 
 })

--- a/tests/clients/FlexbaseClient.Credit.test.ts
+++ b/tests/clients/FlexbaseClient.Credit.test.ts
@@ -37,7 +37,7 @@ test("FlexbaseClient get company credit no id", async () => {
 
 test("FlexbaseClient request pay with flexbase success", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 1000, session: "test", mode: 'immediate', bnplRequest: 'test' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 1000, session: "test", mode: 'immediate', requestId: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(true);
@@ -49,7 +49,7 @@ test("FlexbaseClient request pay with flexbase success", async () => {
 
 test("FlexbaseClient request pay with flexbase failure", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: badApiKey, amount: 1000, mode: 'immediate', bnplRequest: 'test' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: badApiKey, amount: 1000, mode: 'immediate', requestId: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(false);
@@ -57,7 +57,7 @@ test("FlexbaseClient request pay with flexbase failure", async () => {
 
 test("FlexbaseClient request pay with flexbase error", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: errorApiKey, amount: 1000, mode: 'immediate', bnplRequest: 'test' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: errorApiKey, amount: 1000, mode: 'immediate', requestId: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(false);
@@ -65,7 +65,7 @@ test("FlexbaseClient request pay with flexbase error", async () => {
 
 test("FlexbaseClient request pay with flexbase denied", async () => {
 
-    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: deniedApiKey, amount: 1000, mode: 'immediate', bnplRequest: 'test' });
+    const response = await testFlexbaseClient.requestPayWithFlexbase({apiKey: deniedApiKey, amount: 1000, mode: 'immediate', requestId: 'test' });
 
     expect(response).not.toBeNull();
     expect(response!.approved).toBe(false);
@@ -73,11 +73,11 @@ test("FlexbaseClient request pay with flexbase denied", async () => {
 
 test("FlexbaseClient request pay with flexbase invalid payload", async () => {
 
-    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: '', amount: 1000, mode: 'immediate', bnplRequest: 'test' })).rejects.toThrow();
+    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: '', amount: 1000, mode: 'immediate', requestId: 'test' })).rejects.toThrow();
 
-    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate', bnplRequest: 'test' })).rejects.toThrow();
+    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate', requestId: 'test' })).rejects.toThrow();
 
-    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate', bnplRequest: '' })).rejects.toThrow();
+    await expect(testFlexbaseClient.requestPayWithFlexbase({apiKey: goodApiKey, amount: 0, mode: 'immediate', requestId: '' })).rejects.toThrow();
 
 });
 

--- a/tests/clients/FlexbaseClient.Underwriting.test.ts
+++ b/tests/clients/FlexbaseClient.Underwriting.test.ts
@@ -35,5 +35,25 @@ describe('Underwriting', () => {
         expect(response!.maxLimit).toBe(1000);
         expect(response!.level).toBe(1);
     });
+
+    describe('Get BNPL request', () => {
+        test('Should successfully return the request', async () => {
+            const response = await testFlexbaseClient.getBnplRequest('12345');
+            expect(response.status).toBeTruthy();
+        });
+
+        test('Should throw an error if ID is not provided', async () => {
+            await expect(testFlexbaseClient.getBnplRequest('' as any)).rejects.toThrow('ID is required');
+        });
+
+        test('Should throw an error if not found', async () => {
+            await expect(testFlexbaseClient.getBnplRequest(badCompanyId)).rejects.toThrow('Could not find BNPL request.');
+        });
+
+        test('Should error', async () => {
+            await expect(testFlexbaseClient.getBnplRequest(errorCompanyId)).rejects.toThrow();
+        });
+
+    })
 })
 

--- a/tests/clients/FlexbaseClient.Underwriting.test.ts
+++ b/tests/clients/FlexbaseClient.Underwriting.test.ts
@@ -35,25 +35,5 @@ describe('Underwriting', () => {
         expect(response!.maxLimit).toBe(1000);
         expect(response!.level).toBe(1);
     });
-
-    describe('Get BNPL request', () => {
-        test('Should successfully return the request', async () => {
-            const response = await testFlexbaseClient.getBnplRequest('12345');
-            expect(response.status).toBeTruthy();
-        });
-
-        test('Should throw an error if ID is not provided', async () => {
-            await expect(testFlexbaseClient.getBnplRequest('' as any)).rejects.toThrow('ID is required');
-        });
-
-        test('Should throw an error if not found', async () => {
-            await expect(testFlexbaseClient.getBnplRequest(badCompanyId)).rejects.toThrow('Could not find BNPL request.');
-        });
-
-        test('Should error', async () => {
-            await expect(testFlexbaseClient.getBnplRequest(errorCompanyId)).rejects.toThrow();
-        });
-
-    })
 })
 

--- a/tests/mocks/server/handlers/credit.ts
+++ b/tests/mocks/server/handlers/credit.ts
@@ -1,10 +1,10 @@
-import { compose, rest as mockServer } from 'msw'
+import { compose, rest as mockServer } from 'msw';
 import { PayWithFlexbase } from '../../../../src/index';
 import { badApiKey, badCompanyId, errorApiKey, errorCompanyId, goodApiKey, goodCardId, goodCompanyId, goodUserId, mockUrl } from '../constants';
+import { RequestPayWithFlexbaseResponse } from '../../../../src/models/Credit/PayWithFlexbase';
 
 export const credit_handlers = [
     mockServer.get(mockUrl + "/servicing/minimumDue", (request, response, context) => {
-
         const id = request.url.searchParams.get('id');
 
         if (id === errorCompanyId) {
@@ -59,7 +59,6 @@ export const credit_handlers = [
         return response(res);
     }),
 
-
     mockServer.post<PayWithFlexbase>(mockUrl + "/credit/buyNow", (request, response, context) => {
 
         const { apiKey, amount, session } = request.body;
@@ -95,6 +94,41 @@ export const credit_handlers = [
 
         return response(res);
     }),
+
+    mockServer.get(`${mockUrl}/credit/request/:id`, (request, response, context) => {
+        const { id } = request.params;
+
+        if (id === errorCompanyId) {
+            const res = compose(
+                context.status(400),
+            );
+            return response(res);
+        }
+
+        if (id === badCompanyId) {
+            const res = compose(
+                context.status(200),
+                context.json({
+                    success: false,
+                    error: "Error message"
+                })
+            );
+            return response(res);
+        }
+
+        const res = compose(
+            context.status(200),
+            context.json<RequestPayWithFlexbaseResponse>({
+                success: true,
+                id: id as string,
+                status: 'pending',
+                amount: 1234.00
+            }),
+
+        );
+
+        return response(res);
+    })
 ];
 
 export const credit_error_handlers = [


### PR DESCRIPTION
I did not add try/catch in this endpoint, as I find that having Typescript constantly tell you that something could be null is annoying.