### PR TITLE
add interval field to Card interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.7",
+  "version": "0.33.8",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Card.ts
+++ b/src/clients/FlexbaseClient.Card.ts
@@ -21,6 +21,7 @@ interface UpdateCardForm {
     expensesTypes: {
         amount: number;
         groups: Group[];
+        interval: string;
     };
     notifyUse: boolean;
     shipTo?: Address;

--- a/src/models/Card/Card.ts
+++ b/src/models/Card/Card.ts
@@ -17,6 +17,7 @@ export interface Card {
     expensesTypes: {
         amount: number;
         groups: Group[];
+        interval: string;
     };
     expirationDate: string;
     holder: string;

--- a/tests/clients/FlexbaseClient.Card.test.ts
+++ b/tests/clients/FlexbaseClient.Card.test.ts
@@ -116,6 +116,7 @@ test("FlexbaseClient update user card success", async () => {
     expect(response?.card?.cardName).toBe('Gas Card');
     expect(response?.card?.cardNumber).toBe('1234');
     expect(response?.card?.creditLimit).toBe(5000);
+    expect(response?.card?.expensesTypes?.interval).toBe('monthly');
 });
 
 test("FlexbaseClient update user card failure", async () => {

--- a/tests/mocks/server/constants.ts
+++ b/tests/mocks/server/constants.ts
@@ -48,7 +48,7 @@ export const goodCardId = "good card";
 export const badCardId = "bad card";
 export const errorCardId = "error card";
 export const cardType = "physical";
-export const updateCardForm = { expensesTypes: { amount: 5000, groups: [] }, notifyUse: true, creditLimit: 5000, cardName: 'Gas Card' }
+export const updateCardForm = { expensesTypes: { amount: 5000, groups: [], interval: 'monthly' }, notifyUse: true, creditLimit: 5000, cardName: 'Gas Card' }
 
 export const counterparty = { routingNumber: "213456787989", accountNumber: "2983433", accountType: "Checking", name: "Jane Doe" }
 export const paymentBodyReq = { type: 'achPayment', amount: '1000.0', accountId: '01234', direction: 'credit', description: 'New payment', counterparty }

--- a/tests/mocks/server/handlers/card.ts
+++ b/tests/mocks/server/handlers/card.ts
@@ -128,6 +128,11 @@ export const card_handlers = [
                     cardNumber: "1234",
                     creditLimit: 5000,
                     status: 'active',
+                    expensesTypes: {
+                        amount: 5000,
+                        groups: ['MATERIALSUPPLIERS'],
+                        interval: 'monthly',
+                    },
                 },
             }),
 


### PR DESCRIPTION
This PR was created to add the field `interval` to the interface `Card` to control the spending by categories selected.