### PR TITLE
Get the company payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.8",
+  "version": "0.33.10",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.9",
+  "version": "0.33.8",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -16,6 +16,7 @@ interface Payment {
     amount: string;
     status: string;
     datePosted: string;
+    origin: string;
 }
 
 export class FlexbaseClientCompany extends FlexbaseClientBase {

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -32,7 +32,7 @@ export class FlexbaseClientCompany extends FlexbaseClientBase {
         try {
             return await this.client.url('/servicing/payments').get().json();
         } catch (error) {
-            this.logger.error(`Unable to get company balance data`, error);
+            this.logger.error(`Unable to get company payments`, error);
             return [];
         }
     }

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -12,6 +12,12 @@ interface CompanyBalance {
     graceDate: string;
 }
 
+interface Payment {
+    amount: string;
+    status: string;
+    datePosted: string;
+}
+
 export class FlexbaseClientCompany extends FlexbaseClientBase {
     async getCompanyBalance(companyId: string): Promise<CompanyBalance | null> {
         try {
@@ -19,6 +25,15 @@ export class FlexbaseClientCompany extends FlexbaseClientBase {
         } catch (error) {
             this.logger.error(`Unable to get company balance data`, error);
             return null;
+        }
+    }
+
+    async getCompanyPayments(): Promise<Payment[]> {
+        try {
+            return await this.client.url('/servicing/payments').get().json();
+        } catch (error) {
+            this.logger.error(`Unable to get company balance data`, error);
+            return [];
         }
     }
 }

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -17,6 +17,7 @@ interface Payment {
     status: string;
     datePosted: string;
     origin: string;
+    id: string;
 }
 
 export class FlexbaseClientCompany extends FlexbaseClientBase {

--- a/tests/clients/FlexbaseClient.Company.test.ts
+++ b/tests/clients/FlexbaseClient.Company.test.ts
@@ -1,6 +1,7 @@
 import { goodCompanyId } from "../mocks/server/constants";
 import { testFlexbaseClient } from "../mocks/TestFlexbaseClient";
 
+
 test("FlexbaseClient get company balance success", async () => {
 
     const response = await testFlexbaseClient.getCompanyBalance(goodCompanyId);
@@ -10,4 +11,18 @@ test("FlexbaseClient get company balance success", async () => {
     expect(response?.success).toBe(true);
     expect(response?.availableLimit).toBe(8903);
     expect(response?.minimumDue).toBe(1097);
+});
+
+test("FlexbaseClient get company payments", async () => {
+
+    const response = await testFlexbaseClient.getCompanyPayments();
+
+    expect(response).not.toBeNull();
+    expect(response.length).toBeGreaterThan(0);
+
+    const employee = response[0];
+    expect(employee.status).toBe("succeeded");
+    expect(employee.datePosted).toBe("2022-07-31");
+    expect(employee.amount).toBe("100.00");
+
 });

--- a/tests/clients/FlexbaseClient.Company.test.ts
+++ b/tests/clients/FlexbaseClient.Company.test.ts
@@ -25,6 +25,4 @@ test("FlexbaseClient get company payments", async () => {
     expect(payments.datePosted).toBe("2022-07-31");
     expect(payments.amount).toBe("100.00");
     expect(payments.origin).toBe("manual");
-    
-
 });

--- a/tests/clients/FlexbaseClient.Company.test.ts
+++ b/tests/clients/FlexbaseClient.Company.test.ts
@@ -20,9 +20,11 @@ test("FlexbaseClient get company payments", async () => {
     expect(response).not.toBeNull();
     expect(response.length).toBeGreaterThan(0);
 
-    const employee = response[0];
-    expect(employee.status).toBe("succeeded");
-    expect(employee.datePosted).toBe("2022-07-31");
-    expect(employee.amount).toBe("100.00");
+    const payments = response[0];
+    expect(payments.status).toBe("succeeded");
+    expect(payments.datePosted).toBe("2022-07-31");
+    expect(payments.amount).toBe("100.00");
+    expect(payments.origin).toBe("manual");
+    
 
 });

--- a/tests/mocks/server/handlers/company.ts
+++ b/tests/mocks/server/handlers/company.ts
@@ -33,7 +33,6 @@ export const company_handlers = [
         
         return response(res);
     }),
-
     mockServer.get(mockUrl + "/servicing/payments", (_, response, context) => {
 
 

--- a/tests/mocks/server/handlers/company.ts
+++ b/tests/mocks/server/handlers/company.ts
@@ -44,6 +44,7 @@ export const company_handlers = [
                     status: 'succeeded',
                     amount: '100.00',
                     datePosted: '2022-07-31',
+                    origin: 'manual',
                 }
             ]),
 

--- a/tests/mocks/server/handlers/company.ts
+++ b/tests/mocks/server/handlers/company.ts
@@ -33,4 +33,22 @@ export const company_handlers = [
         
         return response(res);
     }),
-]
+
+    mockServer.get(mockUrl + "/servicing/payments", (_, response, context) => {
+
+
+        const res = compose(
+            context.status(200),
+            context.json([
+                {
+                    status: 'succeeded',
+                    amount: '100.00',
+                    datePosted: '2022-07-31',
+                }
+            ]),
+
+        );
+        
+        return response(res);
+    }),
+];


### PR DESCRIPTION
What has been done:

- Add the `getCompanyPayments` function to get all the company credit payments ( hitting the `/servicing/payments` endpoint ).
- Add the `getCompanyPayments` tests.