### PR TITLE
Update response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.8",
+  "version": "0.33.9",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Plaid.ts
+++ b/src/clients/FlexbaseClient.Plaid.ts
@@ -11,11 +11,12 @@ interface LinkTokenResponse {
 
 interface PublicTokenExchangeResponse {
     success: boolean;
-    response: {
+    response?: {
         accessToken: string;
         accountId: string;
         itemId: string;
         userId: string;
+        unitProcessorToken: string;
     };
 }
 
@@ -40,15 +41,15 @@ export class FlexbaseClientPlaid extends FlexbaseClientBase {
      * Exchange a Plaid `public_token`
      * @param public_token The public token issued by [Plaid Link](https://plaid.com/docs/link/)
      * @param metadata
-     * @returns `true` if successful, otherwise `false`
+     * @returns `success: true` and response data to be used on web if successful, otherwise `success: false`
      */
-    async exchangePlaidPublicToken(public_token: string, metadata: unknown): Promise<boolean> {
+    async exchangePlaidPublicToken(public_token: string, metadata: unknown): Promise<PublicTokenExchangeResponse> {
         try {
             const response = await this.client.url('/plaid/publicToken').post({ public_token, metadata }).json<PublicTokenExchangeResponse>();
-            return response.success;
+            return response;
         } catch {
             this.logger.error('Unable to exchange plaid public token');
-            return false;
+            return { success: false };
         }
     }
 

--- a/tests/clients/FlexbaseClient.Plaid.test.ts
+++ b/tests/clients/FlexbaseClient.Plaid.test.ts
@@ -32,21 +32,22 @@ test("FlexbaseClient exchange plaid public token success", async () => {
 
     const response = await testFlexbaseClient.exchangePlaidPublicToken(goodPlaidPublicToken, null);
 
-    expect(response).toBe(true);
+    expect(response.success).toBe(true);
+    expect(response.response?.accessToken).toBe(plaidLinkToken);
 });
 
 test("FlexbaseClient exchange plaid public token failure", async () => {
 
     const response = await testFlexbaseClient.exchangePlaidPublicToken(badPlaidPublicToken, null);
 
-    expect(response).toBe(false);
+    expect(response.success).toBe(false);
 });
 
 test("FlexbaseClient exchange plaid public token 400", async () => {
 
     const response = await testFlexbaseClient.exchangePlaidPublicToken("400", null);
 
-    expect(response).toBe(false);
+    expect(response.success).toBe(false);
 });
 
 test("FlexbaseClient update plaid link token success", async () => {


### PR DESCRIPTION
We need to update the response from `/plaid/publicToken` because the response data
we will use it in other calls (especially on Unit flows when we use Plaid integration)