### PR TITLE
Change the response structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.10",
+  "version": "0.33.11",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -20,6 +20,11 @@ interface Payment {
     id: string;
 }
 
+interface PaymentsResponse {
+    success: boolean;
+    payments: Payment[];
+}
+
 export class FlexbaseClientCompany extends FlexbaseClientBase {
     async getCompanyBalance(companyId: string): Promise<CompanyBalance | null> {
         try {
@@ -30,12 +35,18 @@ export class FlexbaseClientCompany extends FlexbaseClientBase {
         }
     }
 
-    async getCompanyPayments(): Promise<Payment[]> {
+    async getCompanyPayments(): Promise<Payment[] | null> {
         try {
-            return await this.client.url('/servicing/payments').get().json();
+            const response = await this.client.url('/servicing/payments').get().json<PaymentsResponse>();
+
+            if (!response.success) {
+                return null;
+            }
+
+            return response.payments;
         } catch (error) {
             this.logger.error(`Unable to get company payments`, error);
-            return [];
+            return null;
         }
     }
 }

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -1,4 +1,5 @@
 import { FlexbaseClientBase } from './FlexbaseClient.Base';
+import { FlexbaseResponse } from '../models/FlexbaseResponse';
 
 interface CompanyBalance {
     success: boolean;
@@ -20,9 +21,8 @@ interface Payment {
     id: string;
 }
 
-interface PaymentsResponse {
-    success: boolean;
-    payments: Payment[];
+interface PaymentsResponse extends FlexbaseResponse {
+    payments?: Payment[];
 }
 
 export class FlexbaseClientCompany extends FlexbaseClientBase {
@@ -35,18 +35,18 @@ export class FlexbaseClientCompany extends FlexbaseClientBase {
         }
     }
 
-    async getCompanyPayments(): Promise<Payment[] | null> {
+    async getCompanyPayments(): Promise<PaymentsResponse> {
         try {
             const response = await this.client.url('/servicing/payments').get().json<PaymentsResponse>();
 
             if (!response.success) {
-                return null;
+                this.logger.error('Unable to get company payments', response.error);
             }
 
-            return response.payments;
+            return response;
         } catch (error) {
             this.logger.error(`Unable to get company payments`, error);
-            return null;
+            return { success: false, error: 'Unable to get company payments', payments: [] };
         }
     }
 }

--- a/tests/clients/FlexbaseClient.Company.test.ts
+++ b/tests/clients/FlexbaseClient.Company.test.ts
@@ -13,13 +13,14 @@ test("FlexbaseClient get company balance success", async () => {
     expect(response?.minimumDue).toBe(1097);
 });
 
-test("FlexbaseClient get company payments success", async () => {
+test("FlexbaseClient get company payments", async () => {
 
     const response = await testFlexbaseClient.getCompanyPayments();
 
     expect(response).not.toBeNull();
+    expect(response?.payments?.length).toBeGreaterThan(0);
 
-    const payment = response![0];
+    const payment = response.payments![0];
 
     expect(payment?.status).toBe("succeeded");
     expect(payment?.datePosted).toBe("2022-07-31");

--- a/tests/clients/FlexbaseClient.Company.test.ts
+++ b/tests/clients/FlexbaseClient.Company.test.ts
@@ -13,16 +13,16 @@ test("FlexbaseClient get company balance success", async () => {
     expect(response?.minimumDue).toBe(1097);
 });
 
-test("FlexbaseClient get company payments", async () => {
+test("FlexbaseClient get company payments success", async () => {
 
     const response = await testFlexbaseClient.getCompanyPayments();
 
     expect(response).not.toBeNull();
-    expect(response.length).toBeGreaterThan(0);
 
-    const payments = response[0];
-    expect(payments.status).toBe("succeeded");
-    expect(payments.datePosted).toBe("2022-07-31");
-    expect(payments.amount).toBe("100.00");
-    expect(payments.origin).toBe("manual");
+    const payment = response![0];
+
+    expect(payment?.status).toBe("succeeded");
+    expect(payment?.datePosted).toBe("2022-07-31");
+    expect(payment?.amount).toBe("100.00");
+    expect(payment?.origin).toBe("manual");
 });

--- a/tests/mocks/server/handlers/company.ts
+++ b/tests/mocks/server/handlers/company.ts
@@ -38,14 +38,15 @@ export const company_handlers = [
 
         const res = compose(
             context.status(200),
-            context.json([
-                {
+            context.json({
+                success: true,
+                payments: [{
                     status: 'succeeded',
                     amount: '100.00',
                     datePosted: '2022-07-31',
                     origin: 'manual',
-                }
-            ]),
+                }]
+            }),
 
         );
         


### PR DESCRIPTION
In this PR I changed the response structure for the `getCompanyPayments` function so if the result is success I only get the payments array instead all the object `({ success: true, payments: [...]})`,