### PR TITLE
Add option null to interface UpdateCardForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.14",
+  "version": "0.33.15",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Card.ts
+++ b/src/clients/FlexbaseClient.Card.ts
@@ -19,13 +19,13 @@ interface CardResponse extends FlexbaseResponse {
 
 interface UpdateCardForm {
     expensesTypes: {
-        amount: number;
+        amount: number | null;
         groups: Group[];
-        interval: string;
+        interval: string | null;
     };
     notifyUse: boolean;
     shipTo?: Address;
-    creditLimit: number;
+    creditLimit: number | null;
     cardName?: string;
 }
 


### PR DESCRIPTION
This PR was created to add the `null` option to `creditLimit`, `amount`, and `interval` to the UpdateCardForm interface so that when the user updates the unlimited card interval this data can be passed as `null`.