### PR TITLE
Projects client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.21",
+  "version": "0.33.22",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Project.ts
+++ b/src/clients/FlexbaseClient.Project.ts
@@ -1,4 +1,4 @@
-import { CreateProjectResponse, Project, ProjectsResponse } from '../models/Project/Project';
+import { CreateOrUpdateProjectResponse, ProjectData, ProjectsResponse } from '../models/Project/Project';
 import { FlexbaseClientBase } from './FlexbaseClient.Base';
 
 export class FlexbaseClientProject extends FlexbaseClientBase {
@@ -11,9 +11,9 @@ export class FlexbaseClientProject extends FlexbaseClientBase {
         }
     }
 
-    async createOrUpdateProject(projectData: Project): Promise<CreateProjectResponse | null> {
+    async createOrUpdateProject(projectData: ProjectData): Promise<CreateOrUpdateProjectResponse | null> {
         try {
-            const response = await this.client.url('/project').post(projectData).json<CreateProjectResponse>();
+            const response = await this.client.url('/project').post(projectData).json<CreateOrUpdateProjectResponse>();
 
             return response;
         } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export { Card } from './models/Card/Card';
 export { OnboardingStatus } from './models/Onboarding/OnboardingStatus';
 export { Business } from './models/Business/Business';
 export { BusinessOwner } from './models/Business/BusinessOwner';
-export { Project, ProjectsResponse, CreateProjectResponse } from './models/Project/Project';
+export { ProjectData, ProjectsResponse, CreateOrUpdateProjectResponse } from './models/Project/Project';
 export { Statement } from './models/Banking/Statement';
 export { Relationship } from './models/Banking/Constants';
 export { Counterparty, CounterpartyForm, CounterpartyRequest, CtrParty } from './models/Banking/Counterparty';

--- a/src/models/Project/Project.ts
+++ b/src/models/Project/Project.ts
@@ -4,7 +4,7 @@ export interface ProjectData {
     id?: string;
     name?: string;
     description?: string;
-    clientId?: string | null;
+    clientId?: string;
     location?: Address;
 }
 
@@ -26,6 +26,6 @@ export interface CreateOrUpdateProjectResponse {
     id: string;
     location: Address;
     name: string;
-    clientId: string | null;
+    clientId?: string;
     companyId: string;
 }

--- a/src/models/Project/Project.ts
+++ b/src/models/Project/Project.ts
@@ -1,9 +1,10 @@
 import { Address } from '../Address/Address';
 
-export interface Project {
+export interface ProjectData {
     id?: string;
     name?: string;
     description?: string;
+    clientId?: string | null;
     location?: Address;
 }
 
@@ -20,9 +21,11 @@ export interface ProjectsResponse {
     }
 }
 
-export interface CreateProjectResponse {
+export interface CreateOrUpdateProjectResponse {
     description: string;
     id: string;
     location: Address;
     name: string;
+    clientId: string | null;
+    companyId: string;
 }

--- a/src/models/Project/Project.ts
+++ b/src/models/Project/Project.ts
@@ -14,6 +14,10 @@ export interface ProjectsResponse {
     id: string;
     location: Address;
     name: string;
+    client?: {
+        id?: string;
+        companyName?: string;
+    }
 }
 
 export interface CreateProjectResponse {

--- a/tests/clients/FlexbaseClient.Project.test.ts
+++ b/tests/clients/FlexbaseClient.Project.test.ts
@@ -12,6 +12,7 @@ test("FlexbaseClient get projects success", async () => {
     const project = response![0];
 
     expect(project.name).toBe('Flexbase');
+    expect(project.client?.companyName).toBe('Test Company')
 });
 
 test("FlexbaseClient get projects failure", async () => {

--- a/tests/clients/FlexbaseClient.Project.test.ts
+++ b/tests/clients/FlexbaseClient.Project.test.ts
@@ -38,6 +38,7 @@ test("FlexbaseClient create project success", async () => {
     const response = await testFlexbaseClient.createOrUpdateProject({ 
         name: "test name",
         description: "test description",
+        clientId: 'testClientId',
         location: {
             street1: "test address",
             street2: 'test address 2',
@@ -49,6 +50,7 @@ test("FlexbaseClient create project success", async () => {
     });
     expect(response).not.toBeNull();
     expect(response?.name).toBe('test name');
+    expect(response?.clientId).toBe('testClientId');
 });
 
 test("FlexbaseClient update project success", async () => {
@@ -57,6 +59,7 @@ test("FlexbaseClient update project success", async () => {
         id: 'testId',
         name: "test name",
         description: "test description",
+        clientId: 'testClientId',
     });
     expect(response).not.toBeNull();
     expect(response?.id).toBe('testId');

--- a/tests/mocks/server/handlers/project.ts
+++ b/tests/mocks/server/handlers/project.ts
@@ -37,6 +37,7 @@ export const project_handlers = [
                 id: "testId",
                 name: "test name",
                 description: "test description",
+                clientId: "testClientId",
                 location: {
                     street1: "test address",
                     city: "test city",

--- a/tests/mocks/server/handlers/project.ts
+++ b/tests/mocks/server/handlers/project.ts
@@ -2,7 +2,7 @@ import { compose, rest as mockServer } from 'msw'
 import { mockUrl } from '../constants';
 
 export const project_handlers = [
-    mockServer.get(mockUrl + "/project/all", (_, response, context) => {
+    mockServer.get(mockUrl + "/project/all?full=true", (_, response, context) => {
 
         const res = compose(
             context.status(200),
@@ -11,6 +11,9 @@ export const project_handlers = [
                     id: "1",
                     name: 'Flexbase',
                     contractId: "2",
+                    client: {
+                        companyName: 'Test Company'
+                    }
                 }
             ]),
 


### PR DESCRIPTION
This PR was created to add the following:

- Add the`clientId` field to the `projectData` interface to identify to which client a certain project belongs when it is created or updated.

- Add to the `ProjectsResponse` interface the following field to add to the `Projects` table the name of the client in the `flexbase-web` repository

```
    client?: {
        id?: string;
        companyName?: string;
    }
```


