### PR TITLE
Banking payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.18",
+  "version": "0.33.19",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Banking.ts
+++ b/src/clients/FlexbaseClient.Banking.ts
@@ -55,7 +55,7 @@ interface PaymentResponse extends FlexbaseResponse {
 }
 
 interface PaymentsListResponse extends FlexbaseResponse {
-  payment?: Payment[];
+  payments?: Payment[];
 }
 
 

--- a/src/clients/FlexbaseClient.Banking.ts
+++ b/src/clients/FlexbaseClient.Banking.ts
@@ -54,6 +54,10 @@ interface PaymentResponse extends FlexbaseResponse {
   payment?: Payment
 }
 
+interface PaymentsListResponse extends FlexbaseResponse {
+  payment?: Payment[];
+}
+
 
 export class FlexbaseClientBanking extends FlexbaseClientBase {
 
@@ -152,6 +156,21 @@ export class FlexbaseClientBanking extends FlexbaseClientBase {
           return { success: false, error };
       }
     }
+
+    async getBankingPayments(companyId: string): Promise<PaymentsListResponse> {
+      try {
+          const response = await this.client.url(`/banking/${companyId}/moneymovement/list`).get().json<PaymentsListResponse>();
+
+          if (!response.success) {
+              this.logger.error('Unable to get the list of payments', response.error);
+          }
+
+          return response;
+      } catch (error) {
+          this.logger.error('Unable to get the list of payments', error);
+          return { success: false, error };
+      }
+  }
 
   // COUNTERPARTIES
   async createBankingCounterparty(companyId: string, counterpartyRequest: CounterpartyRequest): Promise<CounterpartyResponse> {

--- a/tests/clients/FlexbaseClient.Banking.test.ts
+++ b/tests/clients/FlexbaseClient.Banking.test.ts
@@ -151,7 +151,7 @@ test("FlexbaseClient get payment list success", async () => {
 
     expect(response.success).toBeTruthy();
 
-    const payment = response.payment![0];
+    const payment = response.payments![0];
     expect(payment.id).toBe('123');
     expect(payment.status).toBe('Pending');
 });

--- a/tests/clients/FlexbaseClient.Banking.test.ts
+++ b/tests/clients/FlexbaseClient.Banking.test.ts
@@ -144,6 +144,35 @@ test("FlexbaseClient create payment error", async () => {
     expect(response.success).toBeFalsy();
 });
 
+//GET LIST OF PAYMENTS
+test("FlexbaseClient get payment list success", async () => {
+
+    const response = await testFlexbaseClient.getBankingPayments(goodCompanyId);
+
+    expect(response.success).toBeTruthy();
+
+    const payment = response.payment![0];
+    expect(payment.id).toBe('123');
+    expect(payment.status).toBe('Pending');
+});
+
+test("FlexbaseClient get payment list failure", async () => {
+
+    const response = await testFlexbaseClient.getBankingPayments(badCompanyId);
+
+    expect(response.success).toBeFalsy();
+    expect(response.error).toBe('Unable to get the list of payments');
+});
+
+test("FlexbaseClient get payment list error", async () => {
+
+    const response = await testFlexbaseClient.getBankingPayments(errorCompanyId);
+
+    expect(response.success).toBeFalsy();
+});
+
+
+
 // COUNTERPARTIES
 // CREATE COUNTERPARTY
 test("FlexbaseClient create counterparty success", async () => {

--- a/tests/mocks/server/handlers/banking.ts
+++ b/tests/mocks/server/handlers/banking.ts
@@ -184,6 +184,52 @@ export const banking_handlers = [
         return response(res);
     }),
 
+    mockServer.get(mockUrl + "/banking/:companyId/moneymovement/list", (request, response, context) => {
+
+        const { companyId } = request.params;
+
+        if (!companyId || companyId === errorCompanyId) {
+            const res = compose(
+                context.status(400),
+            );
+            return response(res);
+        }
+
+        else if (companyId === badCompanyId) {
+            const res = compose(
+                context.status(200),
+                context.json({
+                    success: false,
+                    error: 'Unable to get the list of payments',
+                })
+            );
+            return response(res);
+        }
+
+        const res = compose(
+            context.status(200),
+            context.json({
+                payment: [
+                    {
+                        id: '123',
+                        companyId: '1234',
+                        payAmount: '$1.25',
+                        payDescription: 'payment test',
+                        payDirection: 'Credit',
+                        payCtrParty: 'Jane Doe',
+                        status: 'Pending',
+                        type: 'achPayment',
+                        ucCustomerId: '463650',
+                        ucDepositId: '603517',
+                    }
+                ],
+                success: true,
+            }),
+
+        );
+        return response(res);
+    }),
+
     // COUNTERPARTIES
     mockServer.post(mockUrl + "/banking/:companyId/moneymovement/counterparty", (request, response, context) => {
 

--- a/tests/mocks/server/handlers/banking.ts
+++ b/tests/mocks/server/handlers/banking.ts
@@ -209,7 +209,7 @@ export const banking_handlers = [
         const res = compose(
             context.status(200),
             context.json({
-                payment: [
+                payments: [
                     {
                         id: '123',
                         companyId: '1234',


### PR DESCRIPTION
What was done: 
- Add the `getBankingPayments` function to get the list of payments hitting this endpoint `/banking/${companyId}/moneymovement/list`
- Add the `PaymentsListResponse` interface to return the payments array
- Add the respective tests for the function