### PR TITLE
Add the result type to the Counterparty interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.23",
+  "version": "0.33.24",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Banking.ts
+++ b/src/clients/FlexbaseClient.Banking.ts
@@ -224,27 +224,26 @@ export class FlexbaseClientBanking extends FlexbaseClientBase {
 
         const response = await this.client.url(`/banking/${companyId}/moneymovement/counterparty/list`)
         .query(params).get().json<CounterpartyApiResponse[]>();
-
         const result = response.map((counterparty) => {
               return {
-                id: counterparty.id,
-                companyId: counterparty.companyId,
-                accountNumber: counterparty.accountNumber,
-                routingNumber: counterparty.response.data.attributes.routingNumber,
-                accountType: counterparty.response.data.attributes.accountType,
-                accountName: counterparty.accountName,
-                accessToken: counterparty.accessToken,
-                asOf: counterparty.asOf,
-                byUser: counterparty.byUser,
-                createdAt: counterparty.createdAt,
-                type: counterparty.type,
-                ucCounterpartyId: counterparty.ucCounterpartyId,
-                ucCustomerId: counterparty.ucCustomerId,
-                version: counterparty.version,
-                name: counterparty.accountName,
+                id: counterparty?.id,
+                companyId: counterparty?.companyId,
+                accountNumber: counterparty?.accountNumber,
+                routingNumber: counterparty?.response.data.attributes.routingNumber,
+                accountType: counterparty?.response.data.attributes.accountType,
+                accountName: counterparty?.accountName,
+                accessToken: counterparty?.accessToken,
+                asOf: counterparty?.asOf,
+                byUser: counterparty?.byUser,
+                createdAt: counterparty?.createdAt,
+                type: counterparty?.type,
+                ucCounterpartyId: counterparty?.ucCounterpartyId,
+                ucCustomerId: counterparty?.ucCustomerId,
+                version: counterparty?.version,
+                name: counterparty?.accountName,
               }
-        })
-        return result;
+        }); 
+        return result
     } catch (error) {
         this.logger.error('Error calling Unit Co. Banking Counterparties', error);
         return null;

--- a/src/clients/FlexbaseClient.Banking.ts
+++ b/src/clients/FlexbaseClient.Banking.ts
@@ -219,31 +219,31 @@ export class FlexbaseClientBanking extends FlexbaseClientBase {
 
   async getBankingCounterparties(companyId: string, options?: BankingParameters): Promise<Counterparty[] | null> {
     try {
-
         const params = this.bankingParams(options);
-
         const response = await this.client.url(`/banking/${companyId}/moneymovement/counterparty/list`)
-        .query(params).get().json<CounterpartyApiResponse[]>();
-        const result = response.map((counterparty) => {
-              return {
-                id: counterparty?.id,
-                companyId: counterparty?.companyId,
-                accountNumber: counterparty?.accountNumber,
-                routingNumber: counterparty?.response.data.attributes.routingNumber,
-                accountType: counterparty?.response.data.attributes.accountType,
-                accountName: counterparty?.accountName,
-                accessToken: counterparty?.accessToken,
-                asOf: counterparty?.asOf,
-                byUser: counterparty?.byUser,
-                createdAt: counterparty?.createdAt,
-                type: counterparty?.type,
-                ucCounterpartyId: counterparty?.ucCounterpartyId,
-                ucCustomerId: counterparty?.ucCustomerId,
-                version: counterparty?.version,
-                name: counterparty?.accountName,
-              }
-        }); 
-        return result
+        .query(params).get().json<CounterpartyApiResponse>();
+
+        if ( response.success && response.counterparties ) {
+            return  response.counterparties.map((counterparty) => ({
+                id: counterparty.id || '',
+                companyId: counterparty.companyId || '',
+                accountNumber: counterparty.accountNumber || '',
+                routingNumber: counterparty.response?.data?.attributes?.routingNumber || '',
+                accountType: counterparty.response?.data?.attributes?.accountType || '',
+                accountName: counterparty.accountName || '',
+                accessToken: counterparty.accessToken || '',
+                asOf: counterparty.asOf || '',
+                byUser: counterparty.byUser || '',
+                createdAt: counterparty.createdAt || '',
+                type: counterparty.type || '',
+                ucCounterpartyId: counterparty.ucCounterpartyId || '',
+                ucCustomerId: counterparty.ucCustomerId || '',
+                version: counterparty.version || -1,
+                name: counterparty.accountName || '',
+            }));
+        }
+
+        return null;
     } catch (error) {
         this.logger.error('Error calling Unit Co. Banking Counterparties', error);
         return null;

--- a/src/models/Banking/Counterparty.ts
+++ b/src/models/Banking/Counterparty.ts
@@ -1,4 +1,5 @@
 import { Address } from "./Constants";
+import { FlexbaseResponse } from '../FlexbaseResponse';
 
 export interface CtrParty {
     accessToken: string;
@@ -14,25 +15,24 @@ export interface CtrParty {
 }
 
 export interface CounterpartyForm {
-    unitProcessorToken?: string;
-    routingNumber?: string;
-    accountNumber?: string;
-    accountType?: string;
-    address?: Address;
-    type?: string;
+    unitProcessorToken: string;
+    routingNumber: string;
+    accountNumber: string;
+    accountType: string;
+    address: Address;
+    type: string;
     name: string;
 }
 
 export interface CounterpartyAttributes {
-    routingNumber?: string;
-    accountNumber?: string;
-    accountType?: string;
-    type?: string;
+    routingNumber: string;
+    accountNumber: string;
+    accountType: string;
+    type: string;
     name: string;
 }
 
-
-export interface CounterpartyApiResponse {
+export interface CounterpartyData {
     accessToken: string;
     asOf: string;
     byUser: string;
@@ -54,6 +54,11 @@ export interface CounterpartyApiResponse {
     };
 }
 
+
+export interface CounterpartyApiResponse extends FlexbaseResponse {
+    counterparties: Array<Partial<CounterpartyData>>;
+}
+
 export interface Counterparty {
     accessToken: string;
     asOf: string;
@@ -67,13 +72,13 @@ export interface Counterparty {
     version: number;
     accountName: string;
     accountNumber: string;
-    routingNumber?: string;
-    accountType?: string;
+    routingNumber: string;
+    accountType: string;
     name: string;
 }
 
 
 export interface CounterpartyRequest {
     type: string;
-    counterparty: CounterpartyForm;
+    counterparty: Partial<CounterpartyForm>;
 }

--- a/src/models/Banking/Counterparty.ts
+++ b/src/models/Banking/Counterparty.ts
@@ -1,3 +1,5 @@
+import { Address } from "./Constants";
+
 export interface CtrParty {
     accessToken: string;
     asOf: string;
@@ -21,8 +23,16 @@ export interface CounterpartyForm {
     name: string;
 }
 
+export interface CounterpartyAttributes {
+    routingNumber?: string;
+    accountNumber?: string;
+    accountType?: string;
+    type?: string;
+    name: string;
+}
 
-export interface Counterparty {
+
+export interface CounterpartyApiResponse {
     accessToken: string;
     asOf: string;
     byUser: string;
@@ -39,17 +49,27 @@ export interface Counterparty {
     accountType: string;
     response: {
         data: {
-            attributes: CounterpartyForm;
+            attributes: CounterpartyAttributes;
         }
     };
 }
 
-export interface Address {
-    city: string;
-    state: string;
-    street: string;
-    country: string;
-    postalCode: string;
+export interface Counterparty {
+    accessToken: string;
+    asOf: string;
+    byUser: string;
+    companyId: string;
+    createdAt: string;
+    id: string;
+    type: string;
+    ucCounterpartyId: string;
+    ucCustomerId: string;
+    version: number;
+    accountName: string;
+    accountNumber: string;
+    routingNumber?: string;
+    accountType?: string;
+    name: string;
 }
 
 

--- a/src/models/Banking/Counterparty.ts
+++ b/src/models/Banking/Counterparty.ts
@@ -1,5 +1,3 @@
-import { Address } from "./Constants";
-
 export interface CtrParty {
     accessToken: string;
     asOf: string;
@@ -13,6 +11,17 @@ export interface CtrParty {
     version: number;
 }
 
+export interface CounterpartyForm {
+    unitProcessorToken?: string;
+    routingNumber?: string;
+    accountNumber?: string;
+    accountType?: string;
+    address?: Address;
+    type?: string;
+    name: string;
+}
+
+
 export interface Counterparty {
     accessToken: string;
     asOf: string;
@@ -24,21 +33,25 @@ export interface Counterparty {
     ucCounterpartyId: string;
     ucCustomerId: string;
     version: number;
-    name: string;
+    accountName: string;
     routingNumber: string;
     accountNumber: string;
     accountType: string;
+    response: {
+        data: {
+            attributes: CounterpartyForm;
+        }
+    };
 }
 
-export interface CounterpartyForm {
-    unitProcessorToken?: string;
-    routingNumber?: string;
-    accountNumber?: string;
-    accountType?: string;
-    address?: Address;
-    type?: string;
-    name: string;
+export interface Address {
+    city: string;
+    state: string;
+    street: string;
+    country: string;
+    postalCode: string;
 }
+
 
 export interface CounterpartyRequest {
     type: string;

--- a/src/models/Banking/Payment.ts
+++ b/src/models/Banking/Payment.ts
@@ -28,5 +28,5 @@ export interface PaymentForm {
     description: string;
     counterpartyId?: string;
     plaidProcessorToken?: string;
-    counterparty?: CounterpartyForm;
+    counterparty?: Partial<CounterpartyForm>;
 }

--- a/tests/clients/FlexbaseClient.Banking.test.ts
+++ b/tests/clients/FlexbaseClient.Banking.test.ts
@@ -223,7 +223,7 @@ test('FlexbaseClient get counterparties list success', async () => {
     const ctrParty = response.counterparties![0];
     expect(ctrParty?.id).toBe('01234');
     expect(ctrParty?.type).toBe('achCounterparty');
-    expect(ctrParty?.name).toBe('April Oniel');
+    expect(ctrParty?.accountName).toBe('April Oniel');
     expect(ctrParty?.routingNumber).toBe('812345679');
     expect(ctrParty?.accountNumber).toBe('1000000001');
 });

--- a/tests/clients/FlexbaseClient.Banking.test.ts
+++ b/tests/clients/FlexbaseClient.Banking.test.ts
@@ -218,9 +218,10 @@ test('FlexbaseClient get counterparties list success', async () => {
 
     const response = await testFlexbaseClient.getBankingCounterparties(goodCompanyId);
 
-    expect(response.success).toBeTruthy();
+    expect(response).not.toBeNull();
+    expect(response?.length).toBeGreaterThan(0);
 
-    const ctrParty = response.counterparties![0];
+    const ctrParty = response![0];
     expect(ctrParty?.id).toBe('01234');
     expect(ctrParty?.type).toBe('achCounterparty');
     expect(ctrParty?.accountName).toBe('April Oniel');
@@ -232,15 +233,7 @@ test('FlexbaseClient get counterparties list failure', async () => {
 
     const response = await testFlexbaseClient.getBankingCounterparties(badCompanyId);
 
-    expect(response.success).toBeFalsy();
-    expect(response.error).toBe('Error calling Unit Co. Banking Counterparties');
-});
-
-test('FlexbaseClient get counterparties list error', async () => {
-
-    const response = await testFlexbaseClient.getBankingCounterparties(errorCompanyId);
-
-    expect(response.success).toBeFalsy();
+    expect(response).toBeNull();
 });
 
 // DEPOSITS

--- a/tests/mocks/server/constants.ts
+++ b/tests/mocks/server/constants.ts
@@ -1,3 +1,5 @@
+import { CounterpartyForm, PaymentForm } from '../../../src';
+
 export const mockUrl = "http://localhost:3000";
 export const tokenUrl = mockUrl + "/auth/token";
 export const tokenUrl2 = mockUrl + "/auth/token2";
@@ -50,8 +52,8 @@ export const errorCardId = "error card";
 export const cardType = "physical";
 export const updateCardForm = { expensesTypes: { amount: 5000, groups: [], interval: 'monthly' }, notifyUse: true, creditLimit: 5000, cardName: 'Gas Card' }
 
-export const counterparty = { routingNumber: "213456787989", accountNumber: "2983433", accountType: "Checking", name: "Jane Doe" }
-export const paymentBodyReq = { type: 'achPayment', amount: '1000.0', accountId: '01234', direction: 'credit', description: 'New payment', counterparty }
+export const counterparty: Partial<CounterpartyForm> = { routingNumber: "213456787989", accountNumber: "2983433", accountType: "Checking", name: "Jane Doe" }
+export const paymentBodyReq: PaymentForm = { type: 'achPayment', amount: '1000.0', accountId: '01234', direction: 'credit', description: 'New payment', counterparty }
 export const createDebitCard = { type: 'businessDebitCard', limits: { dailyPurchase: 7000 } }
 export const updateDebitCard = { id: '01234', type: 'businessDebitCard', limits: { dailyPurchase: 10000 } }
 export const createUnitcoToken = { scope: 'transactions cards cards-write cards-sensitive-write', verificationCode: '301299', verificationToken: 'NewToken' }

--- a/tests/mocks/server/handlers/banking.ts
+++ b/tests/mocks/server/handlers/banking.ts
@@ -254,37 +254,44 @@ export const banking_handlers = [
 
         const { companyId } = request.params;
 
-        if (!companyId || companyId === errorCompanyId) {
-            const res = compose(
-                context.status(400)
-            );
-            return response(res);
-        } else if (companyId === badCompanyId) {
+       if (companyId === badCompanyId) {
             const res = compose(
                 context.status(200),
-                context.json({
-                    success: false,
-                    error: 'Error calling Unit Co. Banking Counterparties'
-                })
+                context.json(null)
             );
             return response(res);
         }
 
         const res = compose(
             context.status(200),
-            context.json({
-                success: true,
-                counterparties: [
+            context.json([
                     {
                         id: '01234',
-                        type: 'achCounterparty',
+                        companyId: '1234',
+                        accountNumber: '1000000001',
+                        response: {
+                            data: {
+                                attributes: {
+                                    accountType: 'achCounterparty',
+                                    routingNumber: '812345679',
+                                }
+                            }
+                        },
                         accountName: 'April Oniel',
-                        routingNumber: '812345679',
-                        accountNumber: '1000000001'
+                        accessToken: '01234',
+                        asOf: '01/12/2022',
+                        byUser: '12345',
+                        createdAt: '01/12/2022',
+                        type: 'achCounterparty',
+                        ucCounterpartyId: '233414',
+                        ucCustomerId: "563348",
+                        version: 1,
+                        name:"Jane Doe",
                     }
                 ]
-            })
+            ),
         );
+
         return response(res);
     }),
 

--- a/tests/mocks/server/handlers/banking.ts
+++ b/tests/mocks/server/handlers/banking.ts
@@ -278,7 +278,7 @@ export const banking_handlers = [
                     {
                         id: '01234',
                         type: 'achCounterparty',
-                        name: 'April Oniel',
+                        accountName: 'April Oniel',
                         routingNumber: '812345679',
                         accountNumber: '1000000001'
                     }

--- a/tests/mocks/server/handlers/banking.ts
+++ b/tests/mocks/server/handlers/banking.ts
@@ -264,7 +264,7 @@ export const banking_handlers = [
 
         const res = compose(
             context.status(200),
-            context.json([
+            context.json({success: true, counterparties: [
                     {
                         id: '01234',
                         companyId: '1234',
@@ -288,7 +288,7 @@ export const banking_handlers = [
                         version: 1,
                         name:"Jane Doe",
                     }
-                ]
+                ]}
             ),
         );
 


### PR DESCRIPTION
**DESCRIPTION**

I created this PR to add the `response` object on the Counterparty interface, to get the `accountType` value and change the `name` type to `accountName` since the `GET /banking/{{companyId}}/moneymovement/counterparty/list` response looks like this 

```
{
    "success": true,
    "counterparties": [
        {
            "accessToken": "",
            "accountName": "Jane Doe",
            "accountNumber": "12345569",
            "asOf": "2022-10-17 16:46:01.713+00",
            "companyId": "3595cd4a-8e1e-4f8c-9ebb-beba1b998a0d",
            "createdAt": "2022-10-17 16:46:01.713+00",
            "id": "5c83c000-c7c8-4285-9600-83ce7d1e5553",
            "response": {
                "data": {
                    "attributes": {
                        "accountNumber": "12345569",
                        "accountType": "Checking",
                        "createdAt": "2022-10-17T16:46:01.669Z",
                        "name": "Jane Doe",
                        "permissions": "CreditOnly",
                        "routingNumber": "812345673",
                        "tags": {
                            "companyId": "3595cd4a-8e1e-4f8c-9ebb-beba1b998a0d",
                            "userId": "93916d46-170d-4de4-b916-6daaecf07b01",
                            "tenantId": "3595cd4a-8e1e-4f8c-9ebb-beba1b998a0d"
                        },
                        "type": "Person"
                    },
                    "id": "233414",
                    "relationships": {
                        "customer": {
                            "data": {
                                "id": "563348",
                                "type": "customer"
                            }
                        }
                    },
                    "type": "achCounterparty"
                }
            },
            "type": "achCounterparty",
            "ucCounterpartyId": "233414",
            "ucCustomerId": "563348",
            "userId": "93916d46-170d-4de4-b916-6daaecf07b01",
            "version": 1,
            "tenantId": "3595cd4a-8e1e-4f8c-9ebb-beba1b998a0d"
        }
    ]
}
```