### PR TITLE
Create interface CompanyStatement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.29",
+  "version": "0.33.30",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/models/Servicing/servicing.ts
+++ b/src/models/Servicing/servicing.ts
@@ -21,7 +21,23 @@ export interface PaymentCredit {
       total: string;
   }
 
+  interface CompanyStatement {
+    active?: boolean;
+    address?: string;
+    addressLine2?: string;
+    autopay?: boolean;
+    city?: string;
+    country?: string;
+    creditLimit?: string;
+    frozen?: boolean;
+    name?: string;
+    phone?: string;
+    postalCode?: string;
+    state?: string;
+  }
+
 export interface CreditStatement extends FlexbaseResponse {
+        company?: CompanyStatement,
         invoicesNewPeriodFrom?: string;
         invoicesNewPeriodTo?: string;
         invoicesDuePeriodFrom?: string;

--- a/tests/clients/FlexbaseClient.Servicing.test.ts
+++ b/tests/clients/FlexbaseClient.Servicing.test.ts
@@ -9,6 +9,9 @@ test("FlexbaseClient get credit statement data", async () => {
     expect(response?.success).toBeTruthy();
     expect(response?.invoicesNewPeriodFrom).toBe("2022-08-16");
     expect(response?.invoicesNewPeriodTo).toBe("2022-08-31");
+    expect(response?.company?.active).toBeTruthy();
+    expect(response?.company?.address).toBe("5018 Bridgevalley Ct");
+    expect(response?.company?.name).toBe("Texas Stag Roofing Solutions");
 });
 
 test("FlexbaseClient get credit statement data error", async () => {

--- a/tests/mocks/server/handlers/servicing.ts
+++ b/tests/mocks/server/handlers/servicing.ts
@@ -24,6 +24,20 @@ export const servicing_handlers = [
         const res = compose(
             context.status(200),
             context.json({
+                company: {
+                    active: true,
+                    address: "5018 Bridgevalley Ct",
+                    addressLine2: null,
+                    autopay: false,
+                    city: "Spring",
+                    country: "US",
+                    creditLimit: "$25,000.00",
+                    frozen: false,
+                    name: "Texas Stag Roofing Solutions",
+                    phone: "2102552027",
+                    postalCode: "77379-5148",
+                    state: "TX"
+                },
                 invoicesNewPeriodFrom: "2022-08-16",
                 invoicesNewPeriodTo: "2022-08-31",
                 invoicesNewSum: "2000.00",


### PR DESCRIPTION
This PR was created to create the `CompanyStatement` interface to obtain the company data when the `getCreditStatement` function is executed.