### PR TITLE
Link counterparty response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.30",
+  "version": "0.33.31",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/tests/clients/FlexbaseClient.Banking.test.ts
+++ b/tests/clients/FlexbaseClient.Banking.test.ts
@@ -185,11 +185,13 @@ test('FlexbaseClient create counterparty success', async () => {
         counterparty
     });
 
-    expect(response.success).toBeTruthy();
+    expect(response).not.toBeNull();
 
-    expect(response?.counterparty?.id).toBe('01234');
-    expect(response?.counterparty?.type).toBe('achCounterparty');
-    expect(response?.counterparty?.companyId).toBe(goodCompanyId);
+    expect(response?.id).toBe('01234');
+    expect(response?.accountName).toBe('April Oniel');
+    expect(response?.routingNumber).toBe('812345679');
+    expect(response?.accountNumber).toBe('1000000001');
+
 });
 
 test('FlexbaseClient create counterparty failure', async () => {
@@ -199,18 +201,7 @@ test('FlexbaseClient create counterparty failure', async () => {
         counterparty
     });
 
-    expect(response.success).toBeFalsy();
-    expect(response.error).toBe('Unable to create a Unit Co. Counter Party. Please verify that all the Counterparty banking data required exists');
-});
-
-test('FlexbaseClient create counterparty error', async () => {
-
-    const response = await testFlexbaseClient.createBankingCounterparty(errorCompanyId, {
-        type: 'achCounterparty',
-        counterparty
-    });
-
-    expect(response.success).toBeFalsy();
+    expect(response).toBeNull()
 });
 
 // GET COUNTERPARTIES LIST

--- a/tests/mocks/server/handlers/banking.ts
+++ b/tests/mocks/server/handlers/banking.ts
@@ -238,14 +238,29 @@ export const banking_handlers = [
 
         const res = compose(
             context.status(200),
-            context.json({
-                success: true,
-                counterparty: {
-                    id: '01234',
-                    type: 'achCounterparty',
-                    companyId: goodCompanyId
-                }
-            })
+            context.json({ success: true, counterparty: {
+                        id: '01234',
+                        companyId: '1234',
+                        accountNumber: '1000000001',
+                        response: {
+                            data: {
+                                attributes: {
+                                    accountType: 'Checking',
+                                    routingNumber: '812345679',
+                                }
+                            }
+                        },
+                        accountName: 'April Oniel',
+                        accessToken: '01234',
+                        asOf: '01/12/2022',
+                        byUser: '12345',
+                        createdAt: '01/12/2022',
+                        ucCounterpartyId: '233414',
+                        ucCustomerId: "563348",
+                        version: 1,
+                        name:"Jane Doe",
+                    }}
+                )
         );
         return response(res);
     }),


### PR DESCRIPTION
What was done

- Changed the response structure to return the linked external account with the simplified properties for that I added the `LinkCounterpartyApiResponse` type, this was made to avoid errors to update the counterparty list when adding a new one