### PR TITLE
Add the createdAt field to the company

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.32",
+  "version": "0.33.33",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Company.ts
+++ b/src/clients/FlexbaseClient.Company.ts
@@ -36,6 +36,7 @@ interface ResponseCompanyData extends FlexbaseResponse {
     state: string;
     postalCode: string;
     country: string;
+    createdAt: string;
 }
 
 interface CompanyResponse extends FlexbaseResponse {
@@ -84,6 +85,7 @@ export class FlexbaseClientCompany extends FlexbaseClientBase {
                     companyName: response?.companyName,
                     phone: response?.phone,
                     doingBusinessAs: response?.dba,
+                    createdAt: response?.createdAt,
                     address: {
                         line1: response?.address,
                         line2: response?.addressLine2,

--- a/src/models/Business/Company.ts
+++ b/src/models/Business/Company.ts
@@ -10,6 +10,7 @@ export interface Company {
     website?: string;
     monthlyExpenditure?: string;
     phone?: string;
+    createdAt?: string;
     address?: {
         line1?: string;
         line2?: string;

--- a/tests/clients/FlexbaseClient.Company.test.ts
+++ b/tests/clients/FlexbaseClient.Company.test.ts
@@ -35,5 +35,6 @@ test("FlexbaseClient get company data", async () => {
 
     expect(response.company?.id).toBe(goodCompanyId);
     expect(response.company?.companyName).toBe("DBD Company");
+    expect(response.company?.createdAt).toBe("2022-03-02 19:54:34.421+00");
     expect(response.company?.address?.line1).toBe("544 Winder Trl");
 });

--- a/tests/mocks/server/handlers/company.ts
+++ b/tests/mocks/server/handlers/company.ts
@@ -64,6 +64,7 @@ export const company_handlers = [
                 doingBusinessAs: 'test dba',
                 address: '544 Winder Trl',
                 addressLine2: 'test line2',
+                createdAt: '2022-03-02 19:54:34.421+00',
             }),
         );
         


### PR DESCRIPTION
This PR was created to add the field createdAt to the interface `CompanyResponse` and `ResponseCompanyData`