### PR TITLE
Change the getPerson response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexbase-client",
-  "version": "0.33.33",
+  "version": "0.33.34",
   "description": "Flexbase api client",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/clients/FlexbaseClient.Person.ts
+++ b/src/clients/FlexbaseClient.Person.ts
@@ -57,22 +57,22 @@ export class FlexbaseClientPerson extends FlexbaseClientBase {
         }
     }
 
-    async getPerson(userId: string): Promise<PersonResponse> {
+    async getPerson(userId: string): Promise<Person | null> {
         if (!userId) {
             throw new Error('userId is required');
         }
 
         try {
-            const response = await this.client.url(`/user/${userId}`).get().json<PersonResponse>();
+            const response = await this.client.url(`/user/${userId}`).get().json<Person>();
 
-            if (!response.success) {
-                this.logger.error(`Unable to get person ${userId}`, response.error);
+            if (!response) {
+                this.logger.error(`Unable to get person ${userId}`);
             }
 
             return response;
         } catch (error) {
             this.logger.error(`Unable to get person ${userId}`, error);
-            return { success: false, error: `Unable to get person ${userId}` };
+            return null;
         }
     }
 

--- a/tests/clients/FlexbaseClient.Person.test.ts
+++ b/tests/clients/FlexbaseClient.Person.test.ts
@@ -41,21 +41,15 @@ test("FlexbaseClient get person success", async () => {
 
     const response = await testFlexbaseClient.getPerson(goodUserId);
     expect(response).not.toBeNull();
-    expect(response.success).toBe(true);
 });
 
 test("FlexbaseClient get person error", async () => {
 
     const response = await testFlexbaseClient.getPerson(errorUserId);
 
-    expect(response?.success).toBe(false);
+    expect(response).toBeNull();
 });
 
-test("FlexbaseClient get person failure", async () => {
-
-    const response = await testFlexbaseClient.getPerson(badUserId);
-    expect(response.error).toBe('Error message');
-});
 
 test("FlexbaseClient get person no user id", async () => {
 

--- a/tests/mocks/server/handlers/person.ts
+++ b/tests/mocks/server/handlers/person.ts
@@ -63,20 +63,14 @@ export const person_handlers = [
         else if (userId === badUserId) {
             const res = compose(
                 context.status(200),
-                context.json({
-                    success: false,
-                    error: "Error message"
-                })
+                context.json({})
             );
             return response(res);
         }
 
         const res = compose(
             context.status(200),
-            context.json({
-                success: true,
-                usr: { id: goodUserId },
-            }),
+            context.json({ id: goodUserId }),
         );
         return response(res);
 


### PR DESCRIPTION
Change the `getPerson` response since the API returns the person object directly without the success and error variables.